### PR TITLE
Import jaconv

### DIFF
--- a/Japanese_Yomigana.ipynb
+++ b/Japanese_Yomigana.ipynb
@@ -784,6 +784,7 @@
         "colab": {}
       },
       "source": [
+        "import jaconv",
         "def sentence_to_yomi(sentence):\n",
         "  mecabTagger = MeCab.Tagger()\n",
         "  node = mecabTagger.parseToNode(sentence)\n",


### PR DESCRIPTION
jaconvをimportしないとsentence_to_yomiでエラーが発生します